### PR TITLE
Add set_allow_unreachable_blocks method to Context

### DIFF
--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -274,6 +274,8 @@ extern {
     pub fn gcc_jit_context_set_bool_option(ctx: *mut gcc_jit_context,
                                            option: gcc_jit_bool_option,
                                            value: c_int);
+    pub fn gcc_jit_context_set_bool_allow_unreachable_blocks(ctx: *mut gcc_jit_context,
+                                                             value: c_int);
     pub fn gcc_jit_context_compile(ctx: *mut gcc_jit_context) -> *mut gcc_jit_result;
     pub fn gcc_jit_context_compile_to_file(ctx: *mut gcc_jit_context,
                                            kind: gcc_jit_output_kind,

--- a/src/context.rs
+++ b/src/context.rs
@@ -240,6 +240,12 @@ impl<'ctx> Context<'ctx> {
         }
     }
 
+    pub fn set_allow_unreachable_blocks(&self, value: bool) {
+        unsafe {
+            gccjit_sys::gcc_jit_context_set_bool_allow_unreachable_blocks(self.ptr, value as i32);
+        }
+    }
+
     /// Compiles the context and returns a CompileResult that contains
     /// the means to access functions and globals that have currently
     /// been JIT compiled.


### PR DESCRIPTION
Enabling this option is necessary for avoiding an error when bootstrapping rustc using cg_gcc.