### PR TITLE
Feature-gate `LValue::global_set_readonly` by `master`

### DIFF
--- a/src/lvalue.rs
+++ b/src/lvalue.rs
@@ -140,6 +140,7 @@ impl<'ctx> LValue<'ctx> {
         }
     }
 
+    #[cfg(feature="master")]
     pub fn global_set_readonly(&self) {
         unsafe {
             gccjit_sys::gcc_jit_global_set_readonly(self.ptr);


### PR DESCRIPTION
`gccjit_sys::gcc_jit_global_set_readonly` is only available with `feature = "master"`.