### PR TITLE
Update libc version to 0.2.140 to support s390x

### DIFF
--- a/gccjit_sys/Cargo.toml
+++ b/gccjit_sys/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/swgillespie/gccjit.rs"
 master = []
 
 [dependencies]
-libc = "0.1.6"
+libc = "0.2"


### PR DESCRIPTION
Adresses https://github.com/rust-lang/rust/issues/109774.

I've simply chosen the current latest libc version - let me know if you prefer anything else.