### PR TITLE
feat(RValue): Allow Setting Locations after Creation

### DIFF
--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -666,4 +666,8 @@ extern {
 
     #[cfg(feature="master")]
     pub fn gcc_jit_function_new_temp(func: *mut gcc_jit_function, loc: *mut gcc_jit_location, ty: *mut gcc_jit_type) -> *mut gcc_jit_lvalue;
+
+    #[cfg(feature="master")]
+    pub fn gcc_jit_rvalue_set_location(rvalue: *mut gcc_jit_rvalue,
+                                       loc: *mut gcc_jit_location);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1215,7 +1215,6 @@ pub unsafe fn from_ptr<'ctx>(ptr: *mut gccjit_sys::gcc_jit_context) -> Context<'
 #[cfg(test)]
 mod tests {
     use super::super::*;
-    use std::default::Default;
     use std::mem;
 
     #[test]

--- a/src/location.rs
+++ b/src/location.rs
@@ -27,10 +27,10 @@ impl<'ctx> fmt::Debug for Location<'ctx> {
 }
 
 impl<'ctx> Location<'ctx> {
-    pub fn null<'a>() -> Self {
+    pub fn null() -> Self {
         Location {
             marker: std::marker::PhantomData,
-            ptr: unsafe { core::ptr::null_mut() },
+            ptr: core::ptr::null_mut(),
         }
     }
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -26,6 +26,15 @@ impl<'ctx> fmt::Debug for Location<'ctx> {
     }
 }
 
+impl<'ctx> Location<'ctx> {
+    pub fn null<'a>() -> Self {
+        Location {
+            marker: std::marker::PhantomData,
+            ptr: unsafe { core::ptr::null_mut() },
+        }
+    }
+}
+
 pub unsafe fn from_ptr<'ctx>(ptr: *mut gccjit_sys::gcc_jit_location) -> Location<'ctx> {
     Location {
         marker: PhantomData,

--- a/src/rvalue.rs
+++ b/src/rvalue.rs
@@ -103,7 +103,7 @@ impl<'ctx> RValue<'ctx> {
 
     /// Sets the location of this RValue.
     #[cfg(feature="master")]
-    pub unsafe fn set_location(&self, loc: Location) {
+    pub fn set_location(&self, loc: Location) {
         unsafe {
             let loc_ptr = location::get_ptr(&loc);
             gccjit_sys::gcc_jit_rvalue_set_location(self.ptr, loc_ptr);

--- a/src/rvalue.rs
+++ b/src/rvalue.rs
@@ -101,6 +101,15 @@ impl<'ctx> RValue<'ctx> {
         }
     }
 
+    /// Sets the location of this RValue.
+    #[cfg(feature="master")]
+    pub unsafe fn set_location(&self, loc: Location) {
+        unsafe {
+            let loc_ptr = location::get_ptr(&loc);
+            gccjit_sys::gcc_jit_rvalue_set_location(self.ptr, loc_ptr);
+        }
+    }
+
     /// Given an RValue x and a Field f, returns an RValue representing
     /// C's x.f.
     pub fn access_field(&self,


### PR DESCRIPTION
It's necessary for a minimal modification to the file in order to support native locations of libgccjit. 
e.g.  The support of `cg_gcc` for operators, in builder.rs, implemented using a version using the binary operator `*` , which hard coded the location to be NULL. This must be filled by this set_location();
e.g. It may be necessary to set location for locals introduced by cg_ssa, which seems to be stored by `DebugInfoBuilderMethods::dbg_var_addr`. To save the location of the rvalue, we need a `set_location()`.