### PR TITLE
update gccjit_sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ master = ["gccjit_sys/master"]
 dlopen = ["gccjit_sys/dlopen"]
 
 [dependencies]
-gccjit_sys = { version = "1.1.1", path = "gccjit_sys" }
+gccjit_sys = { version = "1.1.2", path = "gccjit_sys" }
 
 [package.metadata.docs.rs]
 features = ["master"]


### PR DESCRIPTION
gccjit_sys 1.1.1 passes paths as *const u8. This breaks compilation on architectures where char is signed. 1.1.2 adds a cast to arch independent *const c_char.