### PR TITLE
expose `set_require_tail_call`

### DIFF
--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -506,6 +506,7 @@ extern_maybe_dlopen! {
     fn gcc_jit_lvalue_as_rvalue(lvalue: *mut gcc_jit_lvalue) -> *mut gcc_jit_rvalue;
     fn gcc_jit_rvalue_as_object(rvalue: *mut gcc_jit_rvalue) -> *mut gcc_jit_object;
     fn gcc_jit_rvalue_get_type(rvalue: *mut gcc_jit_rvalue) -> *mut gcc_jit_type;
+    fn gcc_jit_rvalue_set_bool_require_tail_call (call: *mut gcc_jit_rvalue, require_tail_call: c_int);
 
     fn gcc_jit_context_new_rvalue_from_int(ctx: *mut gcc_jit_context,
                                                ty: *mut gcc_jit_type,

--- a/src/rvalue.rs
+++ b/src/rvalue.rs
@@ -190,6 +190,17 @@ impl<'ctx> RValue<'ctx> {
             }
         })
     }
+
+    pub fn set_require_tail_call(&self, require_tail_call: bool) {
+        with_lib(|lib| unsafe {
+            lib.gcc_jit_rvalue_set_bool_require_tail_call(self.ptr, require_tail_call as _);
+
+            #[cfg(debug_assertions)]
+            if let Ok(Some(error)) = self.to_object().get_context().get_last_error() {
+                panic!("{}", error);
+            }
+        })
+    }
 }
 
 pub unsafe fn from_ptr<'ctx>(ptr: *mut gccjit_sys::gcc_jit_rvalue) -> RValue<'ctx> {


### PR DESCRIPTION
required for implementing `become` in the gcc backend