### PR TITLE
Add missing `ToObject` and `ContextGetter` traits implementations

### DIFF
--- a/gccjit_sys/src/lib.rs
+++ b/gccjit_sys/src/lib.rs
@@ -654,8 +654,12 @@ extern_maybe_dlopen! {
     fn gcc_jit_function_type_get_param_count(function_type: *mut gcc_jit_function_type) -> ssize_t;
     fn gcc_jit_type_dyncast_vector(typ: *mut gcc_jit_type) -> *mut gcc_jit_vector_type;
     fn gcc_jit_function_type_get_param_type(function_type: *mut gcc_jit_function_type, index: c_int) -> *mut gcc_jit_type;
+    #[cfg(feature="master")]
+    fn gcc_jit_function_type_as_object(function_type: *mut gcc_jit_function_type) -> *mut gcc_jit_object;
     fn gcc_jit_vector_type_get_num_units(vector_type: *mut gcc_jit_vector_type) -> ssize_t;
     fn gcc_jit_vector_type_get_element_type(vector_type: *mut gcc_jit_vector_type) -> *mut gcc_jit_type;
+    #[cfg(feature="master")]
+    fn gcc_jit_vector_type_as_object(vector_type: *mut gcc_jit_vector_type) -> *mut gcc_jit_object;
     fn gcc_jit_struct_get_field(struct_type: *mut gcc_jit_struct, index: c_int) -> *mut gcc_jit_field;
     fn gcc_jit_type_is_struct(typ: *mut gcc_jit_type) -> *mut gcc_jit_struct;
     fn gcc_jit_struct_get_field_count(struct_type: *mut gcc_jit_struct) -> ssize_t;
@@ -822,6 +826,8 @@ extern_maybe_dlopen! {
     #[cfg(feature="master")]
     fn gcc_jit_region_add_block(region: *mut gcc_jit_region,
                                 block: *mut gcc_jit_block);
+    #[cfg(feature="master")]
+    fn gcc_jit_region_as_object(region: *mut gcc_jit_region) -> *mut gcc_jit_object;
     #[cfg(feature="master")]
     fn gcc_jit_blocks_clone(num_blocks: c_int,
                             blocks: *mut *mut gcc_jit_block,

--- a/src/region.rs
+++ b/src/region.rs
@@ -6,6 +6,7 @@ use std::ptr::NonNull;
 use block::{self, Block};
 use context::Context;
 
+use crate::object::ToObject;
 use crate::{with_lib, with_lib_handle, with_lib_without_error_check};
 
 #[derive(Copy, Clone, Eq, Hash, PartialEq)]
@@ -25,15 +26,14 @@ impl<'ctx> crate::ToObject<'ctx> for Region<'ctx> {
 
 impl<'ctx> crate::ContextGetter<'ctx> for Region<'ctx> {
     fn context(&self) -> crate::ContextRef<'ctx> {
-        use crate::object::ToObject;
-
         self.to_object().context()
     }
 }
 
 impl<'ctx> fmt::Debug for Region<'ctx> {
     fn fmt<'a>(&self, fmt: &mut fmt::Formatter<'a>) -> Result<(), fmt::Error> {
-        unsafe { write!(fmt, "Region ({:?})", get_ptr(self)) }
+        let obj = self.to_object();
+        obj.fmt(fmt)
     }
 }
 

--- a/src/region.rs
+++ b/src/region.rs
@@ -6,12 +6,29 @@ use std::ptr::NonNull;
 use block::{self, Block};
 use context::Context;
 
-use crate::{expect_handle_without_context, with_lib, with_lib_without_error_check};
+use crate::{with_lib, with_lib_handle, with_lib_without_error_check};
 
 #[derive(Copy, Clone, Eq, Hash, PartialEq)]
 pub struct Region<'ctx> {
     marker: PhantomData<&'ctx Context<'ctx>>,
     ptr: NonNull<gccjit_sys::gcc_jit_region>,
+}
+
+impl<'ctx> crate::ToObject<'ctx> for Region<'ctx> {
+    fn to_object(&self) -> crate::Object<'ctx> {
+        with_lib_without_error_check(|lib| unsafe {
+            let ptr = lib.gcc_jit_region_as_object(get_ptr(self));
+            crate::object::from_ptr(ptr).expect("Failed to get Object from Region")
+        })
+    }
+}
+
+impl<'ctx> crate::ContextGetter<'ctx> for Region<'ctx> {
+    fn context(&self) -> crate::ContextRef<'ctx> {
+        use crate::object::ToObject;
+
+        self.to_object().context()
+    }
 }
 
 impl<'ctx> fmt::Debug for Region<'ctx> {
@@ -23,16 +40,15 @@ impl<'ctx> fmt::Debug for Region<'ctx> {
 impl<'ctx> Region<'ctx> {
     #[track_caller]
     pub fn new_block<S: AsRef<str>>(&self, name: S) -> Block<'ctx> {
-        let handle = with_lib_without_error_check(|lib| unsafe {
+        with_lib_handle(self, |lib| unsafe {
             let cstr = CString::new(name.as_ref()).unwrap();
             let ptr = lib.gcc_jit_region_new_block(get_ptr(self), cstr.as_ptr());
             block::from_ptr(ptr)
-        });
-        expect_handle_without_context(handle, "gcc_jit_region_new_block")
+        })
     }
 
     pub fn add_block(&self, blk: Block<'ctx>) {
-        with_lib(&blk, |lib| unsafe {
+        with_lib(self, |lib| unsafe {
             lib.gcc_jit_region_add_block(get_ptr(self), block::get_ptr(&blk));
         })
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,6 +46,14 @@ impl<'ctx> crate::ContextGetter<'ctx> for VectorType<'ctx> {
     }
 }
 
+#[cfg(feature = "master")]
+impl<'ctx> fmt::Debug for VectorType<'ctx> {
+    fn fmt<'a>(&self, fmt: &mut fmt::Formatter<'a>) -> Result<(), fmt::Error> {
+        let obj = self.to_object();
+        obj.fmt(fmt)
+    }
+}
+
 impl<'ctx> VectorType<'ctx> {
     unsafe fn from_ptr(ptr: *mut gccjit_sys::gcc_jit_vector_type) -> Option<VectorType<'ctx>> {
         Some(VectorType {

--- a/src/types.rs
+++ b/src/types.rs
@@ -12,9 +12,7 @@ use gccjit_sys::gcc_jit_types::*;
 
 #[cfg(feature = "master")]
 use crate::lvalue::AttributeValue;
-use crate::{
-    expect_handle_without_context, with_lib, with_lib_handle, with_lib_without_error_check,
-};
+use crate::{with_lib, with_lib_handle, with_lib_without_error_check};
 
 /// A representation of a type, as it is known to the JIT compiler.
 /// Types can be created through the Typeable trait or they can
@@ -31,6 +29,23 @@ pub struct VectorType<'ctx> {
     ptr: NonNull<gccjit_sys::gcc_jit_vector_type>,
 }
 
+#[cfg(feature = "master")]
+impl<'ctx> ToObject<'ctx> for VectorType<'ctx> {
+    fn to_object(&self) -> Object<'ctx> {
+        with_lib_without_error_check(|lib| unsafe {
+            let ptr = lib.gcc_jit_vector_type_as_object(self.get_ptr());
+            object::from_ptr(ptr).expect("Failed to get Object from VectorType")
+        })
+    }
+}
+
+#[cfg(feature = "master")]
+impl<'ctx> crate::ContextGetter<'ctx> for VectorType<'ctx> {
+    fn context(&self) -> crate::ContextRef<'ctx> {
+        self.to_object().context()
+    }
+}
+
 impl<'ctx> VectorType<'ctx> {
     unsafe fn from_ptr(ptr: *mut gccjit_sys::gcc_jit_vector_type) -> Option<VectorType<'ctx>> {
         Some(VectorType {
@@ -41,21 +56,38 @@ impl<'ctx> VectorType<'ctx> {
 
     #[track_caller]
     pub fn get_element_type(&self) -> Type<'ctx> {
-        let typ = with_lib_without_error_check(|lib| unsafe {
+        let call = |lib: &crate::Libgccjit| unsafe {
             from_ptr(lib.gcc_jit_vector_type_get_element_type(self.get_ptr()))
-        });
-        let typ = expect_handle_without_context(typ, "gcc_jit_vector_type_get_element_type");
-        #[cfg(debug_assertions)]
-        if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
-            panic!("{}", error);
+        };
+        #[cfg(not(feature = "master"))]
+        {
+            let typ = with_lib_without_error_check(call);
+            let typ =
+                crate::expect_handle_without_context(typ, "gcc_jit_vector_type_get_element_type");
+            #[cfg(debug_assertions)]
+            if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
+                panic!("{}", error);
+            }
+            typ
         }
-        typ
+        #[cfg(feature = "master")]
+        {
+            with_lib_handle(self, call)
+        }
     }
 
     pub fn get_num_units(&self) -> usize {
-        with_lib_without_error_check(|lib| unsafe {
+        let call = |lib: &crate::Libgccjit| unsafe {
             lib.gcc_jit_vector_type_get_num_units(self.get_ptr()) as usize
-        })
+        };
+        #[cfg(not(feature = "master"))]
+        {
+            with_lib_without_error_check(call)
+        }
+        #[cfg(feature = "master")]
+        {
+            with_lib(self, call)
+        }
     }
 
     fn get_ptr(&self) -> *mut gccjit_sys::gcc_jit_vector_type {
@@ -67,6 +99,23 @@ impl<'ctx> VectorType<'ctx> {
 pub struct FunctionPtrType<'ctx> {
     marker: PhantomData<&'ctx Context<'ctx>>,
     ptr: NonNull<gccjit_sys::gcc_jit_function_type>,
+}
+
+#[cfg(feature = "master")]
+impl<'ctx> ToObject<'ctx> for FunctionPtrType<'ctx> {
+    fn to_object(&self) -> Object<'ctx> {
+        with_lib_without_error_check(|lib| unsafe {
+            let ptr = lib.gcc_jit_function_type_as_object(self.get_ptr());
+            object::from_ptr(ptr).expect("Failed to get Object from FunctionPtrType")
+        })
+    }
+}
+
+#[cfg(feature = "master")]
+impl<'ctx> crate::ContextGetter<'ctx> for FunctionPtrType<'ctx> {
+    fn context(&self) -> crate::ContextRef<'ctx> {
+        self.to_object().context()
+    }
 }
 
 impl<'ctx> fmt::Debug for FunctionPtrType<'ctx> {
@@ -91,34 +140,60 @@ impl<'ctx> FunctionPtrType<'ctx> {
 
     #[track_caller]
     pub fn get_return_type(&self) -> Type<'ctx> {
-        let typ = with_lib_without_error_check(|lib| unsafe {
+        let call = |lib: &crate::Libgccjit| unsafe {
             from_ptr(lib.gcc_jit_function_type_get_return_type(self.get_ptr()))
-        });
-        let typ = expect_handle_without_context(typ, "gcc_jit_function_type_get_return_type");
-        #[cfg(debug_assertions)]
-        if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
-            panic!("{}", error);
+        };
+        #[cfg(not(feature = "master"))]
+        {
+            let typ = with_lib_without_error_check(call);
+            let typ =
+                crate::expect_handle_without_context(typ, "gcc_jit_function_type_get_return_type");
+            #[cfg(debug_assertions)]
+            if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
+                panic!("{}", error);
+            }
+            typ
         }
-        typ
+        #[cfg(feature = "master")]
+        {
+            with_lib_handle(self, call)
+        }
     }
 
     pub fn get_param_count(&self) -> usize {
-        with_lib_without_error_check(|lib| unsafe {
+        let call = |lib: &crate::Libgccjit| unsafe {
             lib.gcc_jit_function_type_get_param_count(self.get_ptr()) as usize
-        })
+        };
+        #[cfg(not(feature = "master"))]
+        {
+            with_lib_without_error_check(call)
+        }
+        #[cfg(feature = "master")]
+        {
+            with_lib(self, call)
+        }
     }
 
     #[track_caller]
     pub fn get_param_type(&self, index: usize) -> Type<'ctx> {
-        let typ = with_lib_without_error_check(|lib| unsafe {
+        let call = |lib: &crate::Libgccjit| unsafe {
             from_ptr(lib.gcc_jit_function_type_get_param_type(self.get_ptr(), index as _))
-        });
-        let typ = expect_handle_without_context(typ, "gcc_jit_function_type_get_param_type");
-        #[cfg(debug_assertions)]
-        if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
-            panic!("{}", error);
+        };
+        #[cfg(not(feature = "master"))]
+        {
+            let typ = with_lib_without_error_check(call);
+            let typ =
+                crate::expect_handle_without_context(typ, "gcc_jit_function_type_get_param_type");
+            #[cfg(debug_assertions)]
+            if let Ok(Some(error)) = typ.to_object().get_context().get_last_error() {
+                panic!("{}", error);
+            }
+            typ
         }
-        typ
+        #[cfg(feature = "master")]
+        {
+            with_lib_handle(self, call)
+        }
     }
 
     fn get_ptr(&self) -> *mut gccjit_sys::gcc_jit_function_type {


### PR DESCRIPTION
Follow-up of #80.